### PR TITLE
Make portfolio images responsive and add mobile navbar toggle

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,12 +1,15 @@
-<header class="navbar navbar-expand navbar-light bg-light bg-gradient border-bottom">
+<header class="navbar navbar-expand-md navbar-light bg-light bg-gradient border-bottom portfolio__navbar">
   <div class="container-fluid">
     <a class="navbar-brand" href="{{ '/' | prepend: site.baseurl }}">{{ site.data.bio.basics.name }}</a>
-    <div class="ms-auto">
-      <ul class="navbar-nav mb-2 mb-lg-0">
-        <a class="nav-link link-animated" href="{{ '/#projects' | prepend: site.baseurl }}">Projects</a>
-        <a class="nav-link link-animated" href="{{ '/#essays' | prepend: site.baseurl }}">Essays</a>
-        <a class="nav-link link-animated" href="{{ '/resume.html' | prepend: site.baseurl }}">Resume</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#portfolioNavbar" aria-controls="portfolioNavbar" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <nav class="collapse navbar-collapse" id="portfolioNavbar">
+      <ul class="navbar-nav ms-auto mb-2 mb-md-0">
+        <li class="nav-item"><a class="nav-link link-animated" href="{{ '/#projects' | prepend: site.baseurl }}">Projects</a></li>
+        <li class="nav-item"><a class="nav-link link-animated" href="{{ '/#essays' | prepend: site.baseurl }}">Essays</a></li>
+        <li class="nav-item"><a class="nav-link link-animated" href="{{ '/resume.html' | prepend: site.baseurl }}">Resume</a></li>
       </ul>
-    </div>
+    </nav>
   </div>
 </header>

--- a/_includes/projects/project-card.html
+++ b/_includes/projects/project-card.html
@@ -1,7 +1,7 @@
 <div class="card mb-3 portfolio__card shadow-lg border-0 portfolio__animate-slide-up">
   <div class="row g-0">
     <div class="col-12 col-md-4">
-      <img src="{{ site.baseurl }}/{{ include.page.image }}" class="rounded-start portfolio__project-image" alt="{{ include.page.title }}">
+      <img src="{{ site.baseurl }}/{{ include.page.image }}" class="img-fluid portfolio__project-image" alt="{{ include.page.title }}">
     </div>
     <div class="col-12 col-md-8">
       <div class="card-body">

--- a/css/site-theme/custom-portfolio.css
+++ b/css/site-theme/custom-portfolio.css
@@ -94,12 +94,12 @@ p a,
   box-shadow: 0 16px 28px color-mix(in oklab, var(--theme-midnight-orchid) 70%, transparent) !important;
 }
 
-.portfolio__project-image {
-    width: 100%;
-    height: 100%;
-    min-height: 220px;
-    object-fit: fill;
-
+.portfolio .portfolio__project-image {
+  width: 100%;
+  height: 100%;
+  min-height: 220px;
+  object-fit: cover;
+  border-radius: var(--bs-card-inner-border-radius) 0 0 var(--bs-card-inner-border-radius);
 }
 
 .portfolio__button {
@@ -141,11 +141,21 @@ p a,
 }
 
 .portfolio img {
-    max-width: fit-content;
-    align-content: center;
-    align-items: center;
-    max-height: fit-content;
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
 
+.portfolio__navbar .navbar-collapse {
+  flex-grow: 0;
+}
+
+.portfolio__navbar .navbar-toggler {
+  border-color: var(--portfolio-color-border);
+}
+
+.portfolio__navbar .navbar-toggler:focus {
+  box-shadow: 0 0 0 0.2rem color-mix(in oklab, var(--portfolio-color-accent) 30%, transparent);
 }
 
 @media (max-width: 768px) {
@@ -162,5 +172,22 @@ p a,
 
   .portfolio__card .card-body {
     padding: 1rem;
+  }
+
+  .portfolio .portfolio__project-image {
+    aspect-ratio: 16 / 9;
+    height: clamp(180px, 45vw, 260px);
+    min-height: 0;
+    border-radius: var(--bs-card-inner-border-radius) var(--bs-card-inner-border-radius) 0 0;
+  }
+
+  .portfolio__navbar .navbar-collapse {
+    width: 100%;
+  }
+
+  .portfolio__navbar .navbar-nav {
+    gap: 0.25rem;
+    padding-top: 0.75rem;
+    text-align: center;
   }
 }


### PR DESCRIPTION
### Motivation
- Improve image scaling across viewports so avatar and project images size responsively and do not overflow their containers.
- Provide a compact navigation experience on small screens by adding a toggleable navbar.

### Description
- Replace the header with a Bootstrap collapsible navbar (`navbar-expand-md`) and add a toggler button and collapse container for small screens (`_includes/header.html`).
- Make project images responsive by adding Bootstrap `img-fluid` to project card `<img>` elements (`_includes/projects/project-card.html`).
- Update CSS (`css/site-theme/custom-portfolio.css`) to make images scale with `max-width: 100%` and `height: auto`, switch project images to `object-fit: cover`, add `aspect-ratio` and `height: clamp(...)` for mobile sizing, and apply border-radius adjustments so images fit card corners.
- Add small-screen navbar styling and toggler focus styles so the collapse behaves correctly and looks consistent with the theme.

### Testing
- Ran static assertions via a `python` script checking files exist and contain expected tokens (assertions passed).
- Built the stylesheet with `npx postcss css/site-theme/custom-portfolio.css --no-map -o /tmp/custom-portfolio.css` (succeeded).
- Attempted `bundle exec jekyll build --baseurl ""` but could not run because the `jekyll` executable is not installed in the local bundle (not executed).
- Attempted `bundle install` to install Jekyll but the operation failed due to `rubygems.org` returning HTTP 403, so full site build verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f88739588328904b7fbb8e99d8fc)