### PR TITLE
Make Download CV a button, ship me.pdf, and refine button colors

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
         <li class="nav-item"><a class="nav-link link-animated" href="{{ '/#projects' | prepend: site.baseurl }}">Projects</a></li>
         <li class="nav-item"><a class="nav-link link-animated" href="{{ '/#essays' | prepend: site.baseurl }}">Essays</a></li>
         <li class="nav-item"><a class="nav-link link-animated" href="{{ '/resume.html' | prepend: site.baseurl }}">Resume</a></li>
-        <li class="nav-item"><a class="nav-link link-animated" href="{{ '/resume.html' | prepend: site.baseurl }}" download="Mahmoud-Ezzat-Moustafa-CV.html">Download CV</a></li>
+        <li class="nav-item portfolio__nav-cta"><a class="btn portfolio__button portfolio__download-button" href="{{ '/me.pdf' | prepend: site.baseurl }}" download="Mahmoud-Ezzat-Moustafa-CV.pdf" aria-label="Download Mahmoud Ezzat Moustafa CV as a PDF">Download CV</a></li>
       </ul>
     </nav>
   </div>

--- a/css/site-theme/custom-portfolio.css
+++ b/css/site-theme/custom-portfolio.css
@@ -23,11 +23,14 @@
   --portfolio-color-text-muted: #eadfff;
   --portfolio-color-border: color-mix(in oklab, var(--theme-lavender-mist) 40%, transparent);
 
-  --portfolio-color-accent: #d8f3ff;
-  --portfolio-color-accent-hover: #dbffd6;
-  --portfolio-color-accent-text: #160f26;
-  --portfolio-color-accent-text-hover: #10201b;
-  --portfolio-color-link: #f0f8ff;
+  --portfolio-color-accent: #f2f9ff;
+  --portfolio-color-accent-hover: #e5ffb8;
+  --portfolio-color-accent-text: #180d2d;
+  --portfolio-color-accent-text-hover: #13240d;
+  --portfolio-color-link: #f8fbff;
+  --portfolio-color-nav-text: #1f1630;
+  --portfolio-color-nav-hover: #4a2474;
+  --portfolio-color-focus-ring: rgba(154, 77, 255, 0.42);
   --portfolio-color-badge-bg: color-mix(in oklab, var(--theme-soft-terracotta) 35%, transparent);
 }
 
@@ -105,15 +108,35 @@ linear-gradient(140deg, var(--portfolio-color-bg-start) 0%, var(--portfolio-colo
 
 .portfolio__button {
   background-color: var(--portfolio-color-accent);
-  border-color: var(--portfolio-color-accent);
+  border: 1px solid var(--portfolio-color-accent);
   color: var(--portfolio-color-accent-text);
-  font-weight: 600;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 24px color-mix(in oklab, var(--theme-midnight-orchid) 28%, transparent);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 .portfolio__button:hover {
   background-color: var(--portfolio-color-accent-hover);
   border-color: var(--portfolio-color-accent-hover);
   color: var(--portfolio-color-accent-text-hover);
+  box-shadow: 0 14px 30px color-mix(in oklab, var(--theme-midnight-orchid) 34%, transparent);
+  transform: translateY(-1px);
+}
+
+.portfolio__button:focus-visible {
+  outline: 3px solid var(--portfolio-color-focus-ring);
+  outline-offset: 3px;
+}
+
+.portfolio__download-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding-inline: 1rem;
+  border-radius: 999px;
+  white-space: nowrap;
 }
 
 .portfolio__badge {
@@ -153,12 +176,23 @@ linear-gradient(140deg, var(--portfolio-color-bg-start) 0%, var(--portfolio-colo
 
 .portfolio__navbar .nav-link,
 .portfolio__navbar .navbar-brand {
-  color: #1f1630;
+  color: var(--portfolio-color-nav-text);
 }
 
 .portfolio__navbar .nav-link:hover,
 .portfolio__navbar .navbar-brand:hover {
-  color: #4a2474;
+  color: var(--portfolio-color-nav-hover);
+}
+
+.portfolio__navbar .portfolio__download-button {
+  margin-inline-start: 0.5rem;
+  min-height: 2.5rem;
+  padding-inline: 1rem;
+}
+
+.portfolio__navbar .portfolio__download-button:hover,
+.portfolio__navbar .portfolio__download-button:focus {
+  color: var(--portfolio-color-accent-text-hover);
 }
 
 .portfolio__navbar .navbar-toggler {
@@ -276,6 +310,11 @@ linear-gradient(140deg, var(--portfolio-color-bg-start) 0%, var(--portfolio-colo
     gap: 0.25rem;
     padding-top: 0.75rem;
     text-align: center;
+  }
+
+  .portfolio__navbar .portfolio__download-button {
+    margin-inline-start: 0;
+    width: 100%;
   }
 
   .portfolio__resume-hero,

--- a/me.pdf
+++ b/me.pdf
@@ -1,0 +1,122 @@
+%PDF-1.4
+%
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 2222 >>
+stream
+BT
+/F1 18 Tf
+72 760 Td
+(Mahmoud Ezzat Moustafa) Tj
+/F1 10 Tf
+0 -22 Td
+(Backend Software Developer, Programmer) Tj
+0 -13 Td
+0 -12 Td
+(Email: Mahmoud.Ezzat.Moustafa@Gmail.com) Tj
+0 -13 Td
+(Phone: +2 01016127655) Tj
+0 -13 Td
+(Website: https://mammhoud.github.io) Tj
+0 -13 Td
+(Location: Cairo, Egypt) Tj
+0 -13 Td
+0 -12 Td
+/F1 13 Tf
+(Professional Summary) Tj
+/F1 10 Tf
+0 -15 Td
+(I am versed in a range of AI and machine learning techniques, including natural) Tj
+0 -13 Td
+(language processing, computer vision, and predictive modeling. I deliver high-) Tj
+0 -13 Td
+(quality results, communicate effectively, and foster collaborative environments. I) Tj
+0 -13 Td
+(actively participate in conferences, workshops, and online courses to stay updated) Tj
+0 -13 Td
+(and bring fresh, innovative ideas to every project.) Tj
+0 -13 Td
+0 -12 Td
+/F1 13 Tf
+(Profiles) Tj
+/F1 10 Tf
+0 -15 Td
+(GitHub: https://github.com/mammhoud) Tj
+0 -13 Td
+(Youtube: https://youtube.com/@mammhoud) Tj
+0 -13 Td
+(Facebook: https://fb.com/mammhoud) Tj
+0 -13 Td
+(LinkedIn: https://linkedin.com/in/mammhoud) Tj
+0 -13 Td
+0 -12 Td
+/F1 13 Tf
+(Skills) Tj
+/F1 10 Tf
+0 -15 Td
+(Languages and Frameworks) Tj
+0 -13 Td
+(Tools and Technologies) Tj
+0 -13 Td
+(Soft Skills) Tj
+0 -13 Td
+0 -12 Td
+/F1 13 Tf
+(Education) Tj
+/F1 10 Tf
+0 -15 Td
+(Modern Academy, Cairo, EG - Computer Science) Tj
+0 -13 Td
+0 -12 Td
+/F1 13 Tf
+(Experience) Tj
+/F1 10 Tf
+0 -15 Td
+(SmartPan \(FODO Apps\) - Technical support and customer service for SmartPan applications.) Tj
+0 -13 Td
+(Huawei - Supported corporate technology projects and installations.) Tj
+0 -13 Td
+0 -12 Td
+/F1 13 Tf
+(Projects) Tj
+/F1 10 Tf
+0 -15 Td
+(Multi Usage Chatbot Utilize - AI chatbot with multi-tenant architecture synchronized with leading ch) Tj
+0 -13 Td
+(Property Website Data Scraper - Scraped property listings and processed historical transaction data.) Tj
+0 -13 Td
+(Content Driven Website Builder - CMS website with dynamic content management and user permissions.) Tj
+0 -13 Td
+(API Gateway with Database Transactions - Developed multi-server API gateway with logging and trackin) Tj
+0 -13 Td
+(Floppy Bird Game - Game application using Java.) Tj
+0 -13 Td
+(POS Desktop App - POS system using C# and MySQL.) Tj
+0 -13 Td
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+2591
+%%EOF

--- a/resume.html
+++ b/resume.html
@@ -12,7 +12,7 @@ layout: home
           <h1 class="display-4 mb-3">{{ site.data.bio.basics.name }}</h1>
           <p class="lead mb-4">{{ site.data.bio.basics.full_summary }}</p>
           <div class="d-flex flex-column flex-sm-row gap-2">
-            <a class="btn portfolio__button" href="{{ '/resume.html' | prepend: site.baseurl }}" download="Mahmoud-Ezzat-Moustafa-CV.html">Download CV</a>
+            <a class="btn portfolio__button portfolio__download-button" href="{{ '/me.pdf' | prepend: site.baseurl }}" download="Mahmoud-Ezzat-Moustafa-CV.pdf" aria-label="Download Mahmoud Ezzat Moustafa CV as a PDF">Download CV</a>
             <button class="btn portfolio__button portfolio__button--secondary" type="button" onclick="window.print()">Print CV</button>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Replace the existing nav-style "Download CV" link with a proper button CTA that downloads a real PDF and reads as a button in the navbar and resume page. 
- Improve the button, hover and focus color tokens so the download CTA meets accessible contrast and visual consistency with the portfolio theme.

### Description
- Replace the navbar Download CV `nav-link` with a button-style CTA that points to `/me.pdf` and uses `download="Mahmoud-Ezzat-Moustafa-CV.pdf"` (file: `_includes/header.html`).
- Update the resume page Download CV action to the same button-style link to `/me.pdf` with the same download filename and ARIA label (file: `resume.html`).
- Add a generated `me.pdf` asset to the repository so the link downloads a real PDF (file: `me.pdf`).
- Adjust CSS variables and add button rules to `css/site-theme/custom-portfolio.css`, including new color tokens (`--portfolio-color-nav-text`, `--portfolio-color-nav-hover`, `--portfolio-color-focus-ring`), stronger button visuals, hover/focus styles, `.portfolio__download-button` layout, and responsive behavior to ensure the control reads as a button rather than a nav-link.

### Testing
- Ran automated assertions that verify both Download CV links now target `me.pdf`, use the renamed download filename `Mahmoud-Ezzat-Moustafa-CV.pdf`, and that `me.pdf` begins with a valid PDF header (these checks passed).
- Executed a contrast-ratio check for updated foreground/background pairs and confirmed all tested pairs meet at least a 4.5:1 ratio (passed).
- Attempted to run `npm run css:build` to rebuild CSS but the job failed due to the environment/npm registry returning `403 Forbidden` for `@tailwindcss/cli` (build blocked by registry access error).
- No headless browser was available in this environment to take visual screenshots, so no visual snapshot tests were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a023ac2508328afd1456265923654)